### PR TITLE
GRUPO-3 Adiciona contagem total de perfis

### DIFF
--- a/UserManagement.API/Controllers/ReportController.cs
+++ b/UserManagement.API/Controllers/ReportController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq; // Necessário para usar .OrderBy()
 using UserManagement.API.Data;
 using UserManagement.API.DTOs;
 using UserManagement.API.Models;
@@ -18,8 +19,14 @@ public class ReportController : ControllerBase
     [HttpGet("tarefas")]
     public ActionResult<List<TarefaDTO>> CreateRelatorio()
     {
-        // Chama o servi�o que retorna a lista
-        var Relatorio = _reportService.CreateRelatorio();
-        return Ok(tarefas);
+        // Chama o serviço que retorna a lista de tarefas
+        var tarefas = _reportService.CreateRelatorio();
+
+        // Organiza a lista em ordem cronológica (da mais antiga para a mais nova)
+        // Substitua "DataCriacao" pelo nome da propriedade de data das suas tarefas, se for diferente.
+        var tarefasOrdenadas = tarefas.OrderBy(t => t.DataCriacao).ToList();
+
+        // Retorna a lista organizada
+        return Ok(tarefasOrdenadas);
     }
 }


### PR DESCRIPTION
Implementa um novo endpoint para obter a contagem total de perfis.

**Detalhes:**
- Novo método `GetPerfisCount()` adicionado ao `PerfisController` (GET /api/Perfis/contagem).
- Novo método `GetTotalPerfisCount()` adicionado ao `PerfilService` para realizar a contagem no banco de dados.

**Objetivo:**
Fornecer um relatório simples e rápido do número total de perfis cadastrados.